### PR TITLE
Quick fix to test hyperlinking in GitHub Pages

### DIFF
--- a/Programming/Languages.md
+++ b/Programming/Languages.md
@@ -1,8 +1,8 @@
 | Name | Command Name | Overview | Further Reading
 | :--: |:------------:|:--------:|:--------------:
-| Bash | bash | [https://www.gnu.org/software/bash/] | [http://write.flossmanuals.net/command-line/introduction/] |
-| Jupyter | jupyter | [https://jupyter.readthedocs.io/en/latest/install.html#install] |
-| Julia | julia | [https://julialang.org/] | [http://ucidatascienceinitiative.github.io/IntroToJulia/] |
-| IPython | ipython | [https://ipython.readthedocs.io/en/stable/install/kernel_install.html] |
-| Python | python | [https://www.analyticsvidhya.com/blog/2016/01/complete-tutorial-learn-data-science-python-scratch-2/] |
-| R     | r | [https://www.rstudio.com/online-learning/#r-programming] |
+| Bash | bash | [https://www.gnu.org/software/bash/](https://www.gnu.org/software/bash/) | [http://write.flossmanuals.net/command-line/introduction/](http://write.flossmanuals.net/command-line/introduction/) |
+| Jupyter | jupyter | [https://jupyter.readthedocs.io/en/latest/install.html#install](https://jupyter.readthedocs.io/en/latest/install.html#install) |
+| Julia | julia | [https://julialang.org/](https://julialang.org/) | [http://ucidatascienceinitiative.github.io/IntroToJulia/](http://ucidatascienceinitiative.github.io/IntroToJulia/) |
+| IPython | ipython | [https://ipython.readthedocs.io/en/stable/install/kernel_install.html](https://ipython.readthedocs.io/en/stable/install/kernel_install.html) |
+| Python | python | [https://www.analyticsvidhya.com/blog/2016/01/complete-tutorial-learn-data-science-python-scratch-2/](https://www.analyticsvidhya.com/blog/2016/01/complete-tutorial-learn-data-science-python-scratch-2/) |
+| R     | r | [https://www.rstudio.com/online-learning/#r-programming](https://www.rstudio.com/online-learning/#r-programming) |

--- a/Programming/Languages.md
+++ b/Programming/Languages.md
@@ -1,8 +1,8 @@
 | Name | Command Name | Overview | Further Reading
 | :--: |:------------:|:--------:|:--------------:
-| Bash | bash | https://www.gnu.org/software/bash/ | http://write.flossmanuals.net/command-line/introduction/ |
-| Jupyter | jupyter | https://jupyter.readthedocs.io/en/latest/install.html#install |
-| Julia | julia | https://julialang.org/ | http://ucidatascienceinitiative.github.io/IntroToJulia/ |
-| IPython | ipython | https://ipython.readthedocs.io/en/stable/install/kernel_install.html |
-| Python | python | https://www.analyticsvidhya.com/blog/2016/01/complete-tutorial-learn-data-science-python-scratch-2/ |
-| R     | r | https://www.rstudio.com/online-learning/#r-programming |
+| Bash | bash | [https://www.gnu.org/software/bash/] | [http://write.flossmanuals.net/command-line/introduction/] |
+| Jupyter | jupyter | [https://jupyter.readthedocs.io/en/latest/install.html#install] |
+| Julia | julia | [https://julialang.org/] | [http://ucidatascienceinitiative.github.io/IntroToJulia/] |
+| IPython | ipython | [https://ipython.readthedocs.io/en/stable/install/kernel_install.html] |
+| Python | python | [https://www.analyticsvidhya.com/blog/2016/01/complete-tutorial-learn-data-science-python-scratch-2/] |
+| R     | r | [https://www.rstudio.com/online-learning/#r-programming] |


### PR DESCRIPTION
Used Markdown linking notation to see if it auto-magics the links on the GitHub Pages version of the site.